### PR TITLE
Switch from using authinfo to failonanomyous endpoint in case anonymous is enabled to get SAML details

### DIFF
--- a/server/backend/opensearch_security_client.ts
+++ b/server/backend/opensearch_security_client.ts
@@ -183,7 +183,7 @@ export class SecurityClient {
   public async getSamlHeader(request: OpenSearchDashboardsRequest) {
     try {
       // response is expected to be an error
-      await this.esClient.asScoped(request).callAsCurrentUser('opensearch_security.authinfo');
+      await this.esClient.asScoped(request).callAsCurrentUser('opensearch_security.failonanonymous');
     } catch (error: any) {
       // the error looks like
       // wwwAuthenticateDirective:

--- a/server/backend/opensearch_security_plugin.ts
+++ b/server/backend/opensearch_security_plugin.ts
@@ -30,6 +30,12 @@ export default function (Client: any, config: any, components: any) {
     },
   });
 
+  Client.prototype.opensearch_security.prototype.failonanonymous = ca({
+    url: {
+      fmt: '/_plugins/_security/failonanonymous',
+    },
+  });
+
   Client.prototype.opensearch_security.prototype.dashboardsinfo = ca({
     url: {
       fmt: '/_plugins/_security/dashboardsinfo',


### PR DESCRIPTION
Switch from using authinfo to failonanomyous endpoint in case anonymous is enabled to get SAML details