### PR TITLE
Create a shell of security-dashboards-plugin that allows another plugin to manage session, but still view the pages from security-dashboards-plugin

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -13,8 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-export const PLUGIN_ID = 'opensearchDashboardsSecurity';
-export const PLUGIN_NAME = 'security-dashboards-plugin';
+export const PLUGIN_ID = 'opensearchDashboardsSecurityPages';
+export const PLUGIN_NAME = 'security-pages-plugin';
 
 export const APP_ID_LOGIN = 'login';
 export const APP_ID_CUSTOMERROR = 'customerror';

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,9 +1,9 @@
 {
-  "id": "securityDashboards",
+  "id": "securityPagesDashboards",
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": [
-    "opensearch_security"
+    "opensearch_security_pages"
   ],
   "requiredPlugins": [
     "navigation",

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -62,14 +62,14 @@ async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   }
 }
 
-const DEFAULT_READONLY_ROLES = ['kibana_read_only'];
-const APP_ID_HOME = 'home';
-const APP_ID_DASHBOARDS = 'dashboards';
-// OpenSearchDashboards app is for legacy url migration
-const APP_ID_OPENSEARCH_DASHBOARDS = 'kibana';
-const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENSEARCH_DASHBOARDS];
-const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
-const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
+// const DEFAULT_READONLY_ROLES = ['kibana_read_only'];
+// const APP_ID_HOME = 'home';
+// const APP_ID_DASHBOARDS = 'dashboards';
+// // OpenSearchDashboards app is for legacy url migration
+// const APP_ID_OPENSEARCH_DASHBOARDS = 'kibana';
+// const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENSEARCH_DASHBOARDS];
+// const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
+// const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
 
 export class SecurityPlugin
   implements
@@ -90,11 +90,11 @@ export class SecurityPlugin
 
     const config = this.initializerContext.config.get<ClientConfigType>();
 
-    const accountInfo = (await fetchAccountInfoSafe(core.http))?.data;
-    const multitenancyEnabled = (await getDashboardsInfoSafe(core.http))?.multitenancy_enabled;
-    const isReadonly = accountInfo?.roles.some((role) =>
-      (config.readonly_mode?.roles || DEFAULT_READONLY_ROLES).includes(role)
-    );
+    // const accountInfo = (await fetchAccountInfoSafe(core.http))?.data;
+    // const multitenancyEnabled = (await getDashboardsInfoSafe(core.http))?.multitenancy_enabled;
+    // const isReadonly = accountInfo?.roles.some((role) =>
+    //   (config.readonly_mode?.roles || DEFAULT_READONLY_ROLES).includes(role)
+    // );
 
     if (apiPermission) {
       core.application.register({
@@ -130,77 +130,77 @@ export class SecurityPlugin
       }
     }
 
-    core.application.register({
-      id: APP_ID_LOGIN,
-      title: 'Security',
-      chromeless: true,
-      appRoute: LOGIN_PAGE_URI,
-      mount: async (params: AppMountParameters) => {
-        const { renderApp } = await import('./apps/login/login-app');
-        // @ts-ignore depsStart not used.
-        const [coreStart, depsStart] = await core.getStartServices();
-        return renderApp(coreStart, params, config);
-      },
-    });
+    // core.application.register({
+    //   id: APP_ID_LOGIN,
+    //   title: 'Security',
+    //   chromeless: true,
+    //   appRoute: LOGIN_PAGE_URI,
+    //   mount: async (params: AppMountParameters) => {
+    //     const { renderApp } = await import('./apps/login/login-app');
+    //     // @ts-ignore depsStart not used.
+    //     const [coreStart, depsStart] = await core.getStartServices();
+    //     return renderApp(coreStart, params, config);
+    //   },
+    // });
 
-    core.application.register({
-      id: APP_ID_CUSTOMERROR,
-      title: 'Security',
-      chromeless: true,
-      appRoute: CUSTOM_ERROR_PAGE_URI,
-      mount: async (params: AppMountParameters) => {
-        const { renderPage } = await import('./apps/customerror/custom-error');
-        const [coreStart] = await core.getStartServices();
-        return renderPage(coreStart, params, config);
-      },
-    });
+    // core.application.register({
+    //   id: APP_ID_CUSTOMERROR,
+    //   title: 'Security',
+    //   chromeless: true,
+    //   appRoute: CUSTOM_ERROR_PAGE_URI,
+    //   mount: async (params: AppMountParameters) => {
+    //     const { renderPage } = await import('./apps/customerror/custom-error');
+    //     const [coreStart] = await core.getStartServices();
+    //     return renderPage(coreStart, params, config);
+    //   },
+    // });
 
-    core.application.registerAppUpdater(
-      new BehaviorSubject<AppUpdater>((app) => {
-        if (!apiPermission && isReadonly && !APP_LIST_FOR_READONLY_ROLE.includes(app.id)) {
-          return {
-            status: AppStatus.inaccessible,
-          };
-        }
-      })
-    );
+    // core.application.registerAppUpdater(
+    //   new BehaviorSubject<AppUpdater>((app) => {
+    //     if (!apiPermission && isReadonly && !APP_LIST_FOR_READONLY_ROLE.includes(app.id)) {
+    //       return {
+    //         status: AppStatus.inaccessible,
+    //       };
+    //     }
+    //   })
+    // );
 
-    if (
-      multitenancyEnabled &&
-      config.multitenancy.enabled &&
-      config.multitenancy.enable_aggregation_view
-    ) {
-      deps.savedObjectsManagement.columns.register(
-        (tenantColumn as unknown) as SavedObjectsManagementColumn<string>
-      );
-      if (!!accountInfo) {
-        const namespacesToRegister = getNamespacesToRegister(accountInfo);
-        deps.savedObjectsManagement.namespaces.registerAlias('Tenant');
-        namespacesToRegister.forEach((ns) => {
-          deps.savedObjectsManagement.namespaces.register(ns as SavedObjectsManagementNamespace);
-        });
-      }
-    }
+    // if (
+    //   multitenancyEnabled &&
+    //   config.multitenancy.enabled &&
+    //   config.multitenancy.enable_aggregation_view
+    // ) {
+    //   deps.savedObjectsManagement.columns.register(
+    //     (tenantColumn as unknown) as SavedObjectsManagementColumn<string>
+    //   );
+    //   if (!!accountInfo) {
+    //     const namespacesToRegister = getNamespacesToRegister(accountInfo);
+    //     deps.savedObjectsManagement.namespaces.registerAlias('Tenant');
+    //     namespacesToRegister.forEach((ns) => {
+    //       deps.savedObjectsManagement.namespaces.register(ns as SavedObjectsManagementNamespace);
+    //     });
+    //   }
+    // }
 
-    // Return methods that should be available to other plugins
-    return {};
+    // // Return methods that should be available to other plugins
+    // return {};
   }
 
   public start(core: CoreStart, deps: SecurityPluginStartDependencies): SecurityPluginStart {
-    const config = this.initializerContext.config.get<ClientConfigType>();
+    // const config = this.initializerContext.config.get<ClientConfigType>();
 
-    setupTopNavButton(core, config);
+    // setupTopNavButton(core, config);
 
-    if (config.ui.autologout) {
-      // logout the user when getting 401 unauthorized, e.g. when session timed out.
-      core.http.intercept({
-        responseError: interceptError(config.auth.logout_url, window),
-      });
-    }
+    // if (config.ui.autologout) {
+    //   // logout the user when getting 401 unauthorized, e.g. when session timed out.
+    //   core.http.intercept({
+    //     responseError: interceptError(config.auth.logout_url, window),
+    //   });
+    // }
 
-    if (config.multitenancy.enabled) {
-      addTenantToShareURL(core);
-    }
+    // if (config.multitenancy.enabled) {
+    //   addTenantToShareURL(core);
+    // }
     return {};
   }
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -87,25 +87,25 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     this.logger.debug('opendistro_security: Setup');
 
     const config$ = this.initializerContext.config.create<SecurityPluginConfigType>();
-    const config: SecurityPluginConfigType = await config$.pipe(first()).toPromise();
+    // const config: SecurityPluginConfigType = await config$.pipe(first()).toPromise();
 
     const router = core.http.createRouter();
 
     const esClient: ILegacyClusterClient = core.opensearch.legacy.createClient(
       'opendistro_security',
       {
-        plugins: [opensearchSecurityConfigurationPlugin, opensearchSecurityPlugin],
+        plugins: [opensearchSecurityPlugin, opensearchSecurityConfigurationPlugin],
       }
     );
 
     this.securityClient = new SecurityClient(esClient);
 
-    const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> = await core.http.createCookieSessionStorageFactory<
-      SecuritySessionCookie
-    >(getSecurityCookieOptions(config));
+    // const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> = await core.http.createCookieSessionStorageFactory<
+    //   SecuritySessionCookie
+    // >(getSecurityCookieOptions(config));
 
     // put logger into route handler context, so that we don't need to pass througth parameters
-    core.http.registerRouteHandlerContext('security_plugin', (context, request) => {
+    core.http.registerRouteHandlerContext('security_pages_plugin', (context, request) => {
       return {
         logger: this.logger,
         esClient,
@@ -113,51 +113,51 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     });
 
     // setup auth
-    const auth: IAuthenticationType = await getAuthenticationHandler(
-      config.auth.type,
-      router,
-      config,
-      core,
-      esClient,
-      securitySessionStorageFactory,
-      this.logger
-    );
-    core.http.registerAuth(auth.authHandler);
+    // const auth: IAuthenticationType = await getAuthenticationHandler(
+    //   config.auth.type,
+    //   router,
+    //   config,
+    //   core,
+    //   esClient,
+    //   securitySessionStorageFactory,
+    //   this.logger
+    // );
+    // core.http.registerAuth(auth.authHandler);
 
     /* Here we check if multitenancy is enabled to ensure if it is, we insert the tenant info (security_tenant) into the resolved, short URL so the page can correctly load with the right tenant information [Fix for issue 1203](https://github.com/opensearch-project/security-dashboards-plugin/issues/1203 */
-    if (config.multitenancy?.enabled) {
-      core.http.registerOnPreResponse((request, preResponse, toolkit) => {
-        addTenantParameterToResolvedShortLink(request);
-        return toolkit.next();
-      });
-    }
+    // if (config.multitenancy?.enabled) {
+    //   core.http.registerOnPreResponse((request, preResponse, toolkit) => {
+    //     addTenantParameterToResolvedShortLink(request);
+    //     return toolkit.next();
+    //   });
+    // }
 
     // Register server side APIs
     defineRoutes(router);
-    defineAuthTypeRoutes(router, config);
+    // defineAuthTypeRoutes(router, config);
 
-    // set up multi-tenant routes
-    if (config.multitenancy?.enabled) {
-      setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);
-    }
+    // // set up multi-tenant routes
+    // if (config.multitenancy?.enabled) {
+    //   setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);
+    // }
 
-    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
-      core.savedObjects.addClientWrapper(
-        2,
-        'security-saved-object-client-wrapper',
-        this.savedObjectClientWrapper.wrapperFactory
-      );
-    }
+    // if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
+    //   core.savedObjects.addClientWrapper(
+    //     2,
+    //     'security-saved-object-client-wrapper',
+    //     this.savedObjectClientWrapper.wrapperFactory
+    //   );
+    // }
 
-    const service = new ReadonlyService(
-      this.logger,
-      this.securityClient,
-      auth,
-      securitySessionStorageFactory,
-      config
-    );
+    // const service = new ReadonlyService(
+    //   this.logger,
+    //   this.securityClient,
+    //   auth,
+    //   securitySessionStorageFactory,
+    //   config
+    // );
 
-    core.security.registerReadonlyService(service);
+    // core.security.registerReadonlyService(service);
 
     return {
       config$,
@@ -169,34 +169,34 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
   public async start(core: CoreStart) {
     this.logger.debug('opendistro_security: Started');
 
-    const config$ = this.initializerContext.config.create<SecurityPluginConfigType>();
-    const config = await config$.pipe(first()).toPromise();
+    // const config$ = this.initializerContext.config.create<SecurityPluginConfigType>();
+    // const config = await config$.pipe(first()).toPromise();
 
-    this.savedObjectClientWrapper.httpStart = core.http;
-    this.savedObjectClientWrapper.config = config;
+    // this.savedObjectClientWrapper.httpStart = core.http;
+    // this.savedObjectClientWrapper.config = config;
 
-    if (config.multitenancy?.enabled) {
-      const globalConfig$: Observable<SharedGlobalConfig> = this.initializerContext.config.legacy
-        .globalConfig$;
-      const globalConfig: SharedGlobalConfig = await globalConfig$.pipe(first()).toPromise();
-      const opensearchDashboardsIndex = globalConfig.opensearchDashboards.index;
-      const typeRegistry: ISavedObjectTypeRegistry = core.savedObjects.getTypeRegistry();
-      const esClient = core.opensearch.client.asInternalUser;
-      const migrationClient = createMigrationOpenSearchClient(esClient, this.logger);
+    // if (config.multitenancy?.enabled) {
+    //   const globalConfig$: Observable<SharedGlobalConfig> = this.initializerContext.config.legacy
+    //     .globalConfig$;
+    //   const globalConfig: SharedGlobalConfig = await globalConfig$.pipe(first()).toPromise();
+    //   const opensearchDashboardsIndex = globalConfig.opensearchDashboards.index;
+    //   const typeRegistry: ISavedObjectTypeRegistry = core.savedObjects.getTypeRegistry();
+    //   const esClient = core.opensearch.client.asInternalUser;
+    //   const migrationClient = createMigrationOpenSearchClient(esClient, this.logger);
 
-      setupIndexTemplate(esClient, opensearchDashboardsIndex, typeRegistry, this.logger);
+    //   setupIndexTemplate(esClient, opensearchDashboardsIndex, typeRegistry, this.logger);
 
-      const serializer: SavedObjectsSerializer = core.savedObjects.createSerializer();
-      const opensearchDashboardsVersion = this.initializerContext.env.packageInfo.version;
-      migrateTenantIndices(
-        opensearchDashboardsVersion,
-        migrationClient,
-        this.securityClient,
-        typeRegistry,
-        serializer,
-        this.logger
-      );
-    }
+    //   const serializer: SavedObjectsSerializer = core.savedObjects.createSerializer();
+    //   const opensearchDashboardsVersion = this.initializerContext.env.packageInfo.version;
+    //   migrateTenantIndices(
+    //     opensearchDashboardsVersion,
+    //     migrationClient,
+    //     this.securityClient,
+    //     typeRegistry,
+    //     serializer,
+    //     this.logger
+    //   );
+    // }
 
     return {
       http: core.http,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -246,7 +246,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         if (request.params.resourceName === ResourceType.serviceAccounts.toLowerCase()) {
@@ -357,7 +357,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.getResource', {
@@ -391,7 +391,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.deleteResource', {
@@ -439,7 +439,7 @@ export function defineRoutes(router: IRouter) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.saveResourceWithoutId', {
@@ -483,7 +483,7 @@ export function defineRoutes(router: IRouter) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.saveResource', {
@@ -536,7 +536,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.authinfo');
@@ -560,7 +560,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.dashboardsinfo');
@@ -569,6 +569,7 @@ export function defineRoutes(router: IRouter) {
           body: esResp,
         });
       } catch (error) {
+        console.log("error: " + error);
         return errorResponse(response, error);
       }
     }
@@ -639,7 +640,7 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
 
       let esResp;
       try {
@@ -720,7 +721,7 @@ export function defineRoutes(router: IRouter) {
       },
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResp;
       try {
         esResp = await client.callAsCurrentUser('opensearch_security.saveAudit', {
@@ -748,7 +749,7 @@ export function defineRoutes(router: IRouter) {
       validate: false,
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       let esResponse;
       try {
         esResponse = await client.callAsCurrentUser('opensearch_security.clearCache');
@@ -780,7 +781,7 @@ export function defineRoutes(router: IRouter) {
       validate: false,
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       try {
         const esResponse = await client.callAsCurrentUser('opensearch_security.restapiinfo');
         return response.ok({
@@ -811,7 +812,7 @@ export function defineRoutes(router: IRouter) {
       },
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       try {
         const esResponse = await client.callAsCurrentUser('opensearch_security.validateDls', {
           body: request.body,
@@ -841,7 +842,7 @@ export function defineRoutes(router: IRouter) {
       },
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       try {
         const esResponse = await client.callAsCurrentUser('opensearch_security.getIndexMappings', {
           index: request.body.index.join(','),
@@ -870,7 +871,7 @@ export function defineRoutes(router: IRouter) {
       validate: false,
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
+      const client = context.security_pages_plugin.esClient.asScoped(request);
       try {
         const esResponse = await client.callAsCurrentUser('opensearch_security.indices');
         return response.ok({


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).