### PR TITLE
Create re-usable sharing panel that dashboards plugins can leverage

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
-  "version": "3.6.0.0",
-  "opensearchDashboardsVersion": "3.6.0",
+  "version": "3.7.0.0",
+  "opensearchDashboardsVersion": "3.7.0",
   "configPath": [
     "opensearch_security"
   ],
@@ -12,7 +12,8 @@
   "optionalPlugins": [
     "managementOverview",
     "dataSource",
-    "dataSourceManagement"
+    "dataSourceManagement",
+    "share"
   ],
   "server": true,
   "ui": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "3.6.0.0",
+  "version": "3.7.0.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
-    "version": "3.6.0",
-    "templateVersion": "3.6.0"
+    "version": "3.7.0",
+    "templateVersion": "3.7.0"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",

--- a/public/apps/resource-sharing/manage_access_panel.tsx
+++ b/public/apps/resource-sharing/manage_access_panel.tsx
@@ -34,6 +34,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { HttpStart } from '../../../../../src/core/public';
+import { fetchUserNameList } from '../configuration/utils/internal-user-list-utils';
+import { fetchRole } from '../configuration/utils/role-list-utils';
 
 const RESOURCE_API_BASE = '/api/resource';
 
@@ -80,6 +82,8 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
   const [initialSignature, setInitialSignature] = useState('');
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [canShare, setCanShare] = useState(true);
+  const [userOptions, setUserOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [roleOptions, setRoleOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
 
   const qualifiedId = `${objectType}:${objectId}`;
 
@@ -111,6 +115,17 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
         const access = (accessResp as any)?.access;
         const userCanShare = access?.can_share || access?.is_owner || access?.is_admin;
         setCanShare(!!userCanShare);
+
+        // Fetch user and role suggestions for typeahead (best-effort, 403 = no suggestions)
+        if (userCanShare) {
+          Promise.all([
+            fetchUserNameList(http, '').catch(() => []),
+            fetchRole(http, '').then((r: any) => Object.keys(r?.data ?? {})).catch(() => []),
+          ]).then(([users, roles]) => {
+            setUserOptions(users.map((u: string) => ({ label: u })));
+            setRoleOptions(roles.map((r: string) => ({ label: r })));
+          });
+        }
 
         // If user can share, fetch full sharing details
         if (userCanShare) {
@@ -295,7 +310,7 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
               <EuiFormRow label="Users" compressed>
                 <EuiComboBox
                   compressed
-                  noSuggestions
+                  options={userOptions}
                   selectedOptions={toOptions(entry.users)}
                   onCreateOption={(v) => {
                     const next = [...entries];
@@ -312,7 +327,7 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
               <EuiFormRow label="Roles" compressed>
                 <EuiComboBox
                   compressed
-                  noSuggestions
+                  options={roleOptions}
                   selectedOptions={toOptions(entry.roles)}
                   onCreateOption={(v) => {
                     const next = [...entries];

--- a/public/apps/resource-sharing/manage_access_panel.tsx
+++ b/public/apps/resource-sharing/manage_access_panel.tsx
@@ -76,6 +76,7 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
   const [accessLevels, setAccessLevels] = useState<string[]>([]);
   const [generalAccess, setGeneralAccess] = useState<string | null>(null);
   const [entries, setEntries] = useState<AccessLevelEntry[]>([]);
+  const [initialEntries, setInitialEntries] = useState<AccessLevelEntry[]>([]);
   const [initialSignature, setInitialSignature] = useState('');
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [canShare, setCanShare] = useState(true);
@@ -86,10 +87,11 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
     let cancelled = false;
     (async () => {
       try {
-        const [typesResp, sharingResp] = await Promise.all([
+        // Fetch types and current user's access (no share permission needed)
+        const [typesResp, accessResp] = await Promise.all([
           http.get(`${RESOURCE_API_BASE}/types`).catch(() => ({ types: [] })),
           http
-            .get(`${RESOURCE_API_BASE}/view`, {
+            .get(`${RESOURCE_API_BASE}/access`, {
               query: { resourceId: qualifiedId, resourceType: objectType },
             })
             .catch(() => null),
@@ -106,28 +108,42 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
         setSupported(true);
         setAccessLevels(typeConfig.access_levels ?? []);
 
-        const shareWith = (sharingResp as any)?.sharing_info?.share_with;
-        const owner = (sharingResp as any)?.sharing_info?.created_by?.user;
-        setCanShare(!currentUsername || owner === currentUsername);
-        console.log('[ManageAccess] objectId:', objectId, 'objectType:', objectType);
-        console.log('[ManageAccess] sharingResp:', JSON.stringify(sharingResp));
-        console.log('[ManageAccess] shareWith:', JSON.stringify(shareWith));
-        const ga =
-          shareWith && typeof shareWith.general_access === 'string'
-            ? shareWith.general_access
-            : null;
-        const parsed = Object.entries(shareWith ?? {})
-          .filter(([k]) => k !== 'general_access')
-          .map(([al, r]: [string, any]) => ({
-            accessLevel: al,
-            users: normalizeList(r?.users),
-            roles: normalizeList(r?.roles),
-          }))
-          .filter((e) => e.users.length > 0 || e.roles.length > 0);
+        const access = (accessResp as any)?.access;
+        const userCanShare = access?.can_share || access?.is_owner || access?.is_admin;
+        setCanShare(!!userCanShare);
 
-        setGeneralAccess(ga);
-        setEntries(parsed);
-        setInitialSignature(JSON.stringify({ generalAccess: ga, entries: parsed }));
+        // If user can share, fetch full sharing details
+        if (userCanShare) {
+          const sharingResp = await http
+            .get(`${RESOURCE_API_BASE}/view`, {
+              query: { resourceId: qualifiedId, resourceType: objectType },
+            })
+            .catch(() => null);
+          if (cancelled) return;
+
+          const shareWith = (sharingResp as any)?.sharing_info?.share_with;
+          const ga =
+            shareWith && typeof shareWith.general_access === 'string'
+              ? shareWith.general_access
+              : null;
+          const parsed = Object.entries(shareWith ?? {})
+            .filter(([k]) => k !== 'general_access')
+            .map(([al, r]: [string, any]) => ({
+              accessLevel: al,
+              users: normalizeList(r?.users),
+              roles: normalizeList(r?.roles),
+            }))
+            .filter((e) => e.users.length > 0 || e.roles.length > 0);
+
+          setGeneralAccess(ga);
+          setEntries(parsed);
+          setInitialEntries(parsed);
+          setInitialSignature(JSON.stringify({ generalAccess: ga, entries: parsed }));
+        } else {
+          // Non-sharer: show general access level read-only
+          const ga = access?.general_access ?? null;
+          setGeneralAccess(ga);
+        }
       } catch (e: any) {
         if (!cancelled) setError(e?.body?.message ?? e?.message ?? 'Failed to load sharing info');
       } finally {
@@ -137,7 +153,7 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
     return () => {
       cancelled = true;
     };
-  }, [http, objectId, objectType]);
+  }, [http, objectId, objectType, qualifiedId]);
 
   const currentSignature = JSON.stringify({ generalAccess, entries });
   const hasChanges = currentSignature !== initialSignature;
@@ -155,15 +171,43 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
     setError(null);
     setSaveSuccess(false);
     try {
+      // Build add: current entries
+      const add: Record<string, any> = {};
+      for (const e of entries) {
+        if (e.users.length > 0 || e.roles.length > 0) {
+          add[e.accessLevel] = {
+            ...(e.users.length > 0 ? { users: e.users } : {}),
+            ...(e.roles.length > 0 ? { roles: e.roles } : {}),
+          };
+        }
+      }
+      // Build revoke: principals in initial but not in current
+      const revoke: Record<string, any> = {};
+      for (const prev of initialEntries) {
+        const cur = entries.find((e) => e.accessLevel === prev.accessLevel);
+        const removedUsers = prev.users.filter((u) => !cur?.users.includes(u));
+        const removedRoles = prev.roles.filter((r) => !cur?.roles.includes(r));
+        if (removedUsers.length > 0 || removedRoles.length > 0) {
+          revoke[prev.accessLevel] = {
+            ...(removedUsers.length > 0 ? { users: removedUsers } : {}),
+            ...(removedRoles.length > 0 ? { roles: removedRoles } : {}),
+          };
+        }
+      }
+
       await http.post(`${RESOURCE_API_BASE}/patch_sharing`, {
         body: JSON.stringify({
           resource_id: qualifiedId,
           resource_type: objectType,
           general_access: generalAccess,
+          add,
+          revoke,
         }),
       });
+      setInitialEntries(entries);
       setInitialSignature(currentSignature);
       setSaveSuccess(true);
+      window.dispatchEvent(new CustomEvent('resourceSharingChanged'));
     } catch (e: any) {
       setError(e?.body?.message ?? e?.message ?? 'Failed to save');
     } finally {
@@ -213,7 +257,10 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
             { value: '', text: 'Private (only owner)' },
             ...accessLevels
               .filter((al) => !al.includes('full_access'))
-              .map((al) => ({ value: al, text: 'Anyone can ' + formatAccessLevel(al).toLowerCase() })),
+              .map((al) => ({
+                value: al,
+                text: 'Anyone can ' + formatAccessLevel(al).toLowerCase(),
+              })),
           ]}
           onChange={(e) => setGeneralAccess(e.target.value || null)}
         />

--- a/public/apps/resource-sharing/manage_access_panel.tsx
+++ b/public/apps/resource-sharing/manage_access_panel.tsx
@@ -1,0 +1,328 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { HttpStart } from '../../../../../src/core/public';
+
+const RESOURCE_API_BASE = '/api/resource';
+
+interface AccessLevelEntry {
+  accessLevel: string;
+  users: string[];
+  roles: string[];
+}
+
+function normalizeList(values?: string[]): string[] {
+  return [...new Set(values ?? [])].filter(Boolean).sort();
+}
+
+function formatAccessLevel(al: string): string {
+  // Strip resource type prefix (e.g. "visualization_view" → "View", "dashboard_full_access" → "Full access")
+  const stripped = al.replace(/^(dashboard|visualization|report[_-]?\w*)_/i, '');
+  return stripped.charAt(0).toUpperCase() + stripped.slice(1).replace(/_/g, ' ');
+}
+
+function toOptions(values: string[]): Array<EuiComboBoxOptionOption<string>> {
+  return values.map((v) => ({ label: v }));
+}
+
+function fromOptions(options: Array<EuiComboBoxOptionOption<string>>): string[] {
+  return normalizeList(options.map((o) => o.label));
+}
+
+interface Props {
+  http: HttpStart;
+  objectId: string;
+  objectType: string;
+  currentUsername?: string;
+}
+
+export function ManageAccessPanel({ http, objectId, objectType, currentUsername }: Props) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [supported, setSupported] = useState(false);
+  const [accessLevels, setAccessLevels] = useState<string[]>([]);
+  const [generalAccess, setGeneralAccess] = useState<string | null>(null);
+  const [entries, setEntries] = useState<AccessLevelEntry[]>([]);
+  const [initialSignature, setInitialSignature] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [canShare, setCanShare] = useState(true);
+
+  const qualifiedId = `${objectType}:${objectId}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [typesResp, sharingResp] = await Promise.all([
+          http.get(`${RESOURCE_API_BASE}/types`).catch(() => ({ types: [] })),
+          http
+            .get(`${RESOURCE_API_BASE}/view`, {
+              query: { resourceId: qualifiedId, resourceType: objectType },
+            })
+            .catch(() => null),
+        ]);
+        if (cancelled) return;
+
+        const typeConfig = (typesResp as any).types?.find((t: any) => t.type === objectType);
+        if (!typeConfig) {
+          setSupported(false);
+          setIsLoading(false);
+          return;
+        }
+
+        setSupported(true);
+        setAccessLevels(typeConfig.access_levels ?? []);
+
+        const shareWith = (sharingResp as any)?.sharing_info?.share_with;
+        const owner = (sharingResp as any)?.sharing_info?.created_by?.user;
+        setCanShare(!currentUsername || owner === currentUsername);
+        console.log('[ManageAccess] objectId:', objectId, 'objectType:', objectType);
+        console.log('[ManageAccess] sharingResp:', JSON.stringify(sharingResp));
+        console.log('[ManageAccess] shareWith:', JSON.stringify(shareWith));
+        const ga =
+          shareWith && typeof shareWith.general_access === 'string'
+            ? shareWith.general_access
+            : null;
+        const parsed = Object.entries(shareWith ?? {})
+          .filter(([k]) => k !== 'general_access')
+          .map(([al, r]: [string, any]) => ({
+            accessLevel: al,
+            users: normalizeList(r?.users),
+            roles: normalizeList(r?.roles),
+          }))
+          .filter((e) => e.users.length > 0 || e.roles.length > 0);
+
+        setGeneralAccess(ga);
+        setEntries(parsed);
+        setInitialSignature(JSON.stringify({ generalAccess: ga, entries: parsed }));
+      } catch (e: any) {
+        if (!cancelled) setError(e?.body?.message ?? e?.message ?? 'Failed to load sharing info');
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [http, objectId, objectType]);
+
+  const currentSignature = JSON.stringify({ generalAccess, entries });
+  const hasChanges = currentSignature !== initialSignature;
+  console.log(
+    '[ManageAccess] hasChanges:',
+    hasChanges,
+    'current:',
+    currentSignature,
+    'initial:',
+    initialSignature
+  );
+
+  async function handleSave() {
+    setIsSaving(true);
+    setError(null);
+    setSaveSuccess(false);
+    try {
+      await http.post(`${RESOURCE_API_BASE}/patch_sharing`, {
+        body: JSON.stringify({
+          resource_id: qualifiedId,
+          resource_type: objectType,
+          general_access: generalAccess,
+        }),
+      });
+      setInitialSignature(currentSignature);
+      setSaveSuccess(true);
+    } catch (e: any) {
+      setError(e?.body?.message ?? e?.message ?? 'Failed to save');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, textAlign: 'center' }}>
+        <EuiLoadingSpinner size="l" />
+      </div>
+    );
+  }
+
+  if (!supported) {
+    return (
+      <div style={{ padding: 16 }}>
+        <EuiText size="s" color="subdued">
+          Access management is not available for this {objectType}.
+        </EuiText>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, maxHeight: 500, overflowY: 'auto' }}>
+      {error && (
+        <>
+          <EuiCallOut color="danger" iconType="alert" title={error} size="s" />
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {saveSuccess && (
+        <>
+          <EuiCallOut color="success" iconType="check" title="Sharing updated" size="s" />
+          <EuiSpacer size="s" />
+        </>
+      )}
+
+      <EuiFormRow label="General access" compressed>
+        <EuiSelect
+          compressed
+          disabled={!canShare}
+          value={generalAccess ?? ''}
+          options={[
+            { value: '', text: 'Private (only owner)' },
+            { value: 'view', text: 'Anyone can view' },
+            { value: 'edit', text: 'Anyone can edit' },
+          ]}
+          onChange={(e) => setGeneralAccess(e.target.value || null)}
+        />
+      </EuiFormRow>
+
+      {accessLevels.length > 0 && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="s" />
+          <EuiTitle size="xxs">
+            <h4>Share with specific users or roles</h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+
+          {entries.map((entry, idx) => (
+            <React.Fragment key={idx}>
+              <EuiFormRow label="Access level" compressed>
+                <EuiSelect
+                  compressed
+                  value={entry.accessLevel}
+                  options={accessLevels.map((al) => ({
+                    value: al,
+                    text: formatAccessLevel(al),
+                  }))}
+                  onChange={(e) => {
+                    const next = [...entries];
+                    next[idx] = { ...entry, accessLevel: e.target.value };
+                    setEntries(next);
+                  }}
+                />
+              </EuiFormRow>
+              <EuiFormRow label="Users" compressed>
+                <EuiComboBox
+                  compressed
+                  noSuggestions
+                  selectedOptions={toOptions(entry.users)}
+                  onCreateOption={(v) => {
+                    const next = [...entries];
+                    next[idx] = { ...entry, users: normalizeList([...entry.users, v]) };
+                    setEntries(next);
+                  }}
+                  onChange={(opts) => {
+                    const next = [...entries];
+                    next[idx] = { ...entry, users: fromOptions(opts) };
+                    setEntries(next);
+                  }}
+                />
+              </EuiFormRow>
+              <EuiFormRow label="Roles" compressed>
+                <EuiComboBox
+                  compressed
+                  noSuggestions
+                  selectedOptions={toOptions(entry.roles)}
+                  onCreateOption={(v) => {
+                    const next = [...entries];
+                    next[idx] = { ...entry, roles: normalizeList([...entry.roles, v]) };
+                    setEntries(next);
+                  }}
+                  onChange={(opts) => {
+                    const next = [...entries];
+                    next[idx] = { ...entry, roles: fromOptions(opts) };
+                    setEntries(next);
+                  }}
+                />
+              </EuiFormRow>
+              <EuiButtonEmpty
+                color="danger"
+                size="s"
+                iconType="trash"
+                onClick={() => setEntries(entries.filter((_, i) => i !== idx))}
+              >
+                Remove
+              </EuiButtonEmpty>
+              <EuiSpacer size="s" />
+            </React.Fragment>
+          ))}
+
+          {canShare && accessLevels.length > entries.length && (
+            <EuiButtonEmpty
+              size="s"
+              iconType="plusInCircle"
+              onClick={() => {
+                const next = accessLevels.find((al) => !entries.some((e) => e.accessLevel === al));
+                if (next) setEntries([...entries, { accessLevel: next, users: [], roles: [] }]);
+              }}
+            >
+              Add access level
+            </EuiButtonEmpty>
+          )}
+        </>
+      )}
+
+      <EuiSpacer size="m" />
+      {!canShare && (
+        <EuiText size="s" color="subdued">
+          You do not have permission to modify sharing for this resource.
+        </EuiText>
+      )}
+      {canShare && (
+        <EuiButton
+          fill
+          size="s"
+          fullWidth
+          isLoading={isSaving}
+          isDisabled={!hasChanges}
+          onClick={handleSave}
+        >
+          Save
+        </EuiButton>
+      )}
+    </div>
+  );
+}

--- a/public/apps/resource-sharing/manage_access_panel.tsx
+++ b/public/apps/resource-sharing/manage_access_panel.tsx
@@ -120,7 +120,9 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
         if (userCanShare) {
           Promise.all([
             fetchUserNameList(http, '').catch(() => []),
-            fetchRole(http, '').then((r: any) => Object.keys(r?.data ?? {})).catch(() => []),
+            fetchRole(http, '')
+              .then((r: any) => Object.keys(r?.data ?? {}))
+              .catch(() => []),
           ]).then(([users, roles]) => {
             setUserOptions(users.map((u: string) => ({ label: u })));
             setRoleOptions(roles.map((r: string) => ({ label: r })));

--- a/public/apps/resource-sharing/manage_access_panel.tsx
+++ b/public/apps/resource-sharing/manage_access_panel.tsx
@@ -211,8 +211,9 @@ export function ManageAccessPanel({ http, objectId, objectType, currentUsername 
           value={generalAccess ?? ''}
           options={[
             { value: '', text: 'Private (only owner)' },
-            { value: 'view', text: 'Anyone can view' },
-            { value: 'edit', text: 'Anyone can edit' },
+            ...accessLevels
+              .filter((al) => !al.includes('full_access'))
+              .map((al) => ({ value: al, text: 'Anyone can ' + formatAccessLevel(al).toLowerCase() })),
           ]}
           onChange={(e) => setGeneralAccess(e.target.value || null)}
         />

--- a/public/apps/resource-sharing/resource-access-management-app.tsx
+++ b/public/apps/resource-sharing/resource-access-management-app.tsx
@@ -79,7 +79,7 @@ const ResourceAccessManagementApp: React.FC<Props> = (props) => {
             </div>
           </EuiPageHeader>
           <EuiSpacer size="m" />
-          <ResourceSharingPanel api={api} toasts={toasts} />
+          <ResourceSharingPanel api={api} toasts={toasts} http={http} />
         </EuiPageBody>
       </EuiPage>
     </>

--- a/public/apps/resource-sharing/resource-sharing-panel.tsx
+++ b/public/apps/resource-sharing/resource-sharing-panel.tsx
@@ -250,7 +250,9 @@ const ShareAccessModal: React.FC<ModalProps> = ({
   useEffect(() => {
     Promise.all([
       fetchUserNameList(http, '').catch(() => []),
-      fetchRole(http, '').then((r: any) => Object.keys(r?.data ?? {})).catch(() => []),
+      fetchRole(http, '')
+        .then((r: any) => Object.keys(r?.data ?? {}))
+        .catch(() => []),
     ]).then(([users, roles]) => {
       setUserOptions(users.map((u: string) => ({ label: u })));
       setRoleOptions(roles.map((r: string) => ({ label: r })));

--- a/public/apps/resource-sharing/resource-sharing-panel.tsx
+++ b/public/apps/resource-sharing/resource-sharing-panel.tsx
@@ -92,6 +92,7 @@ interface Api {
 interface Props {
   api: Api;
   toasts: CoreStart['notifications']['toasts'];
+  http: CoreStart['http'];
 }
 
 const hasSharingInfo = (sw?: ShareWith) =>
@@ -200,6 +201,9 @@ const extractHttpErrorLines = (e: any): string[] => {
 
 /** ---------- Share/Update modal ---------- */
 
+import { fetchUserNameList } from '../configuration/utils/internal-user-list-utils';
+import { fetchRole } from '../configuration/utils/role-list-utils';
+
 interface ModalProps {
   mode: 'create' | 'edit';
   isOpen: boolean;
@@ -209,6 +213,7 @@ interface ModalProps {
   resourceType: string;
   resourceTypeIndex: string;
   accessLevels: string[];
+  http: CoreStart['http'];
 }
 
 const hasNonEmptyRecipients = (r?: ShareRecipients) =>
@@ -231,6 +236,7 @@ const ShareAccessModal: React.FC<ModalProps> = ({
   resourceType,
   resourceTypeIndex,
   accessLevels,
+  http,
 }) => {
   const original = useMemo(() => cloneShareWith(resource?.share_with), [resource?.share_with]);
   const [working, setWorking] = useState<ShareWith>(() =>
@@ -238,6 +244,18 @@ const ShareAccessModal: React.FC<ModalProps> = ({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorLines, setErrorLines] = useState<string[]>([]);
+  const [userOptions, setUserOptions] = useState<Array<{ label: string }>>([]);
+  const [roleOptions, setRoleOptions] = useState<Array<{ label: string }>>([]);
+
+  useEffect(() => {
+    Promise.all([
+      fetchUserNameList(http, '').catch(() => []),
+      fetchRole(http, '').then((r: any) => Object.keys(r?.data ?? {})).catch(() => []),
+    ]).then(([users, roles]) => {
+      setUserOptions(users.map((u: string) => ({ label: u })));
+      setRoleOptions(roles.map((r: string) => ({ label: r })));
+    });
+  }, [http]);
 
   useEffect(() => {
     if (mode === 'edit') setWorking(cloneShareWith(resource.share_with));
@@ -427,7 +445,7 @@ const ShareAccessModal: React.FC<ModalProps> = ({
                 <EuiFormRow label="Users">
                   <EuiComboBox
                     placeholder="Add users…"
-                    noSuggestions
+                    options={userOptions}
                     selectedOptions={toOptions(recipients.users)}
                     onCreateOption={(v) =>
                       setRecipients(levelName, 'users', [...(recipients.users || []), v])
@@ -438,7 +456,7 @@ const ShareAccessModal: React.FC<ModalProps> = ({
                 <EuiFormRow label="Roles">
                   <EuiComboBox
                     placeholder="Add roles…"
-                    noSuggestions
+                    options={roleOptions}
                     selectedOptions={toOptions(recipients.roles)}
                     onCreateOption={(v) =>
                       setRecipients(levelName, 'roles', [...(recipients.roles || []), v])
@@ -449,7 +467,6 @@ const ShareAccessModal: React.FC<ModalProps> = ({
                 <EuiFormRow label="Backend roles">
                   <EuiComboBox
                     placeholder="Add backend roles…"
-                    noSuggestions
                     selectedOptions={toOptions(recipients.backend_roles)}
                     onCreateOption={(v) =>
                       setRecipients(levelName, 'backend_roles', [
@@ -522,7 +539,7 @@ const SharedWithExpanded: React.FC<{ sw?: ShareWith }> = ({ sw }) => {
 const SELECTED_TYPE_SESSION_KEY = 'security::resourceSharing::selectedType';
 
 /** ---------- Main table ---------- */
-export const ResourceSharingPanel: React.FC<Props> = ({ api, toasts }) => {
+export const ResourceSharingPanel: React.FC<Props> = ({ api, toasts, http }) => {
   const [typeOptions, setTypeOptions] = useState<
     Array<{ value: string; text: string; accessLevels: string[] }>
   >([]);
@@ -880,6 +897,7 @@ export const ResourceSharingPanel: React.FC<Props> = ({ api, toasts }) => {
         resourceType={selectedTypeLabel}
         resourceTypeIndex={selectedType}
         accessLevels={currentAccessLevels}
+        http={http}
       />
     </EuiPanel>
   );

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -16,6 +16,7 @@
 import { BehaviorSubject } from 'rxjs';
 import { SavedObjectsManagementColumn } from 'src/plugins/saved_objects_management/public';
 import { i18n } from '@osd/i18n';
+import React from 'react';
 import {
   AppCategory,
   AppMountParameters,
@@ -65,6 +66,7 @@ import {
   SecurityPluginSetupDependencies,
 } from './types';
 import { addTenantToShareURL } from './services/shared-link';
+import { ManageAccessPanel } from './apps/resource-sharing/manage_access_panel';
 import { interceptError } from './utils/logout-utils';
 import { tenantColumn, getNamespacesToRegister } from './apps/configuration/utils/tenant-utils';
 import { getDashboardsInfoSafe } from './utils/dashboards-info-utils';
@@ -135,6 +137,42 @@ export class SecurityPlugin
     const isReadonly = accountInfo?.roles.some((role) =>
       (config.readonly_mode?.roles || DEFAULT_READONLY_ROLES).includes(role)
     );
+
+    // Register "Manage access" panel in the share context menu
+    if (resourceSharingEnabled && deps.share) {
+      deps.share.register({
+        id: 'resourceSharing',
+        getShareMenuItems: ({
+          objectType,
+          objectId,
+        }: {
+          objectType: string;
+          objectId?: string;
+        }) => {
+          if (!objectId) return [];
+          return [
+            {
+              shareMenuItem: {
+                name: 'Manage access',
+                icon: 'lock',
+                sortOrder: 100,
+              },
+              panel: {
+                id: 'manageAccessPanel',
+                title: 'Manage access',
+                width: 500,
+                content: React.createElement(ManageAccessPanel, {
+                  http: core.http as any,
+                  objectId,
+                  objectType,
+                  currentUsername: accountInfo?.user_name,
+                }),
+              },
+            },
+          ];
+        },
+      });
+    }
 
     const mountWrapper = async (params: AppMountParameters, redirect: string) => {
       const { renderApp } = await import('./apps/configuration/configuration-app');

--- a/public/types.ts
+++ b/public/types.ts
@@ -31,6 +31,7 @@ export interface SecurityPluginSetupDependencies {
   savedObjectsManagement: SavedObjectsManagementPluginSetup;
   managementOverview?: ManagementOverViewPluginSetup;
   dataSourceManagement?: DataSourceManagementPluginSetup;
+  share?: { register: (provider: any) => void };
 }
 
 export interface Cluster {

--- a/server/routes/resource_access_management_routes.ts
+++ b/server/routes/resource_access_management_routes.ts
@@ -78,6 +78,7 @@ const postBodySchema = schema.object(
 const SECURITY_RESOURCE_API_PREFIX = '/_plugins/_security/api/resource';
 const LIST_TYPES_API = `${SECURITY_RESOURCE_API_PREFIX}/types`;
 const LIST_SHARING_INFO_API = `${SECURITY_RESOURCE_API_PREFIX}/list`;
+const ACCESS_API = `${SECURITY_RESOURCE_API_PREFIX}/access`;
 const SHARE_API = `${SECURITY_RESOURCE_API_PREFIX}/share`;
 
 export function defineResourceAccessManagementRoutes(router: IRouter, dataSourceEnabled: boolean) {
@@ -186,6 +187,36 @@ export function defineResourceAccessManagementRoutes(router: IRouter, dataSource
     }
   );
 
+  // GET current user's access level for a resource (no share permission required)
+  router.get(
+    {
+      path: '/api/resource/access',
+      validate: {
+        query: schema.object({
+          resourceId: schema.string(),
+          resourceType: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const { resourceId, resourceType } = request.query as {
+          resourceId: string;
+          resourceType: string;
+        };
+        const client = context.core.opensearch.client.asCurrentUser;
+        const result = await client.transport.request({
+          method: 'GET',
+          path: ACCESS_API,
+          querystring: { resource_id: resourceId, resource_type: resourceType },
+        });
+        return response.ok({ body: result.body });
+      } catch (error: any) {
+        return response.customError({ statusCode: error.statusCode || 500, body: error.message });
+      }
+    }
+  );
+
   // PUT share a resource — requires `share_with`
   router.put(
     {
@@ -262,6 +293,8 @@ export function defineResourceAccessManagementRoutes(router: IRouter, dataSource
           resource_id: schema.string({ minLength: 1 }),
           resource_type: schema.string({ minLength: 1 }),
           general_access: schema.nullable(schema.string()),
+          add: schema.maybe(schema.any()),
+          revoke: schema.maybe(schema.any()),
         }),
         query: schema.object({
           dataSourceId: schema.maybe(schema.string()),

--- a/server/routes/resource_access_management_routes.ts
+++ b/server/routes/resource_access_management_routes.ts
@@ -252,4 +252,34 @@ export function defineResourceAccessManagementRoutes(router: IRouter, dataSource
       }
     }
   );
+
+  // PATCH general access for a resource
+  router.post(
+    {
+      path: '/api/resource/patch_sharing',
+      validate: {
+        body: schema.object({
+          resource_id: schema.string({ minLength: 1 }),
+          resource_type: schema.string({ minLength: 1 }),
+          general_access: schema.nullable(schema.string()),
+        }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const client = context.core.opensearch.client.asCurrentUser;
+        const result = await client.transport.request({
+          method: 'PATCH',
+          path: SHARE_API,
+          body: request.body,
+        });
+        return response.ok({ body: result.body });
+      } catch (error: any) {
+        return response.customError({ statusCode: error.statusCode || 500, body: error.message });
+      }
+    }
+  );
 }


### PR DESCRIPTION
### Description

The changes in this PR make security-dashboards-plugin more optionally extensible. Specifically, it creates a reusable sharing fragment that includes:

1. Generally sharing a resource with all users in OSD (tenant-wide, workspace-wide, application-wide)
2. Sharing with target users or roles with typeahead (no SCIM yet)

### Category

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).