### PR TITLE
Update setup-opensearch-dashboards SHA to post-wretry-removal commit

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -52,7 +52,7 @@ runs:
 
     # OSD bootstrap
     - name: Run Dashboard with Security Dashboards Plugin
-      uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+      uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
       with:
         plugin_name: security-dashboards-plugin
         opensearch_dashboards_yml: ${{ inputs.dashboards_config_file }}

--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -94,7 +94,7 @@ jobs:
 
       # OSD bootstrap
       - name: Setup Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -66,7 +66,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: tenancy-disabled-opensearch-dashboards-config.yml

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -69,7 +69,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: cypress-opensearch-dashboards-config.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -105,7 +105,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - id: install-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - id: install-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
            plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run Dashboard with Security Dashboards Plugin
         id: setup-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           built_plugin_name: security-dashboards


### PR DESCRIPTION
Updates the pinned SHA for `setup-opensearch-dashboards` action to `72a7a8a167ed06d83ba65b4d9f60acd08232cd56` (opensearch-project/opensearch-build#6258 merge commit), which removes the nested Wandalen/wretry.action tag reference that violated the SHA-pinning policy.

Signed-off-by: Darshit Chanpura <dchanp@amazon.com>